### PR TITLE
exception handler, Geweke approx, continuous case

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: truncLCdist
 Type: Package
 Title: An Improved Random Number Generator For Some Truncated Distributions
-Version: 0.1.0
+Version: 0.2.0
 Authors@R: c(person(given = c("Euloge", "Clovis"), family = c("Kenne Pagui"), role = "aut", email = "kenne@stat.unipd.it", comment = c(ORCID = "0000-0002-8998-9251")), person(given = "Michele", family = "Lambardi di San Miniato", role = c("aut", "cre"), email = "michele.lambardi@uniud.it", comment = c(ORCID = "0000-0003-2423-4250")))
 URL: https://github.com/mlambardi/truncLCdist
 BugReports: https://github.com/mlambardi/truncLCdist/issues

--- a/R/rtruncLC.R
+++ b/R/rtruncLC.R
@@ -18,6 +18,7 @@
 #' @param b a numeric value for the upper bound of the random variable
 #' @param ... other arguments are are passed to the corresponding distribution-related functions
 #' @param its boolean, whether classical quantile-based sampling à-la truncdist should be performed. Default is FALSE, so Devroye sampling is used instead.
+#' @param maxit integer, maximum number of iterations before imputation
 #' @return A vector with one or more random deviates. An attribute reports on acceptance rates.
 #' @details
 #' This function returns a vector of size n, irrespective of parameters supplied.
@@ -32,7 +33,7 @@
 #' @examples
 #' rtruncLC(10000, "pois", a=15, lambda=1)
 #' rtruncLC(10000, "binom", a=50, size=100, prob=0.15)
-rtruncLC <- function(n, spec, a=-Inf, b=Inf, ..., its=F) {
+rtruncLC <- function(n, spec, a=-Inf, b=Inf, ..., maxit=NULL, its=F) {
   if (any(a > b)) {
     stop("argument a must be less-than-or-equal-to b")
   }
@@ -42,7 +43,7 @@ rtruncLC <- function(n, spec, a=-Inf, b=Inf, ..., its=F) {
   if (!is.null(e <- truncLCdistoptions(paste0(spec, ".exception.raise")))) {
     if (e(a=a, b=b, ...)) {
       e <- truncLCdistoptions(paste0(spec, ".exception.handle"))
-      return(e(n=n, a=a, b=b, ...))
+      return(e(n=n, a=a, b=b, ..., maxit=maxit))
     }
   }
   cont <- truncLCdistoptions(paste0(spec, ".continuous"))
@@ -50,9 +51,9 @@ rtruncLC <- function(n, spec, a=-Inf, b=Inf, ..., its=F) {
     stop(paste0(spec, " not found. Start by setting up ", spec, ".continuous=F or T in options"))
   } else {
     if (cont) { # continuous
-      rtruncLCcontinuous(n, spec, a, b, ...)
+      rtruncLCcontinuous(n, spec, a, b, ..., maxit=maxit)
     } else { # discrete
-      rtruncLCdiscrete(n, spec, floor(a), floor(b), ...)
+      rtruncLCdiscrete(n, spec, floor(a), floor(b), ..., maxit=maxit)
     }
   }
 }

--- a/R/rtruncLCcontinuous.R
+++ b/R/rtruncLCcontinuous.R
@@ -1,5 +1,5 @@
 
-rtruncLCcontinuous <- function(n, spec, a = -Inf, b = +Inf, ...) {
+rtruncLCcontinuous <- function(n, spec, a = -Inf, b = +Inf, maxit=NULL, ...) {
   # gammashape <- function(shape, rate = 1, scale = 1/rate) shape
   # gammascale<- function(shape, rate = 1, scale = 1/rate) scale
   auxmode <- truncLCdistoptions(paste0(spec, ".m"))
@@ -8,6 +8,7 @@ rtruncLCcontinuous <- function(n, spec, a = -Inf, b = +Inf, ...) {
   if (is.null(ld)) stop("probability density unspecified")
   lcdf <- truncLCdistoptions(paste0(spec, ".p"))
   if (is.null(lcdf)) stop("cumulative distribution function unspecified")
+  if (b < a) stop("must be a <= b")
   m <- auxmode(...) # base distribution's mode
   m <- pmax(pmin(m, b), a) # truncated mode, log-concavity applies
   ldm <- ld(m, ..., log=T) # log-probability of the mode
@@ -16,50 +17,41 @@ rtruncLCcontinuous <- function(n, spec, a = -Inf, b = +Inf, ...) {
   lcdfb <- lcdf(b,..., log.p=T)
   # reads like: lk = log(cdf(b) - cdf(a)) = lcdfb + log(1 - exp(-(lcdfb - lcdfa)))
   lk <- lcdfb + Rmpfr::log1mexp(abs(lcdfb - lcdfa))
-  # see Devroye 1986, section 2.3, "Rejection method for log-concave densities. Exponential version"
+  if (!is.finite(lk)) {
+    # can overestimate lk, which is ok, the algorithm is still exact, acceptance rate is lower
+    ldm1 <- abs(truncLCdistoptions(paste0(spec, ".dld"))(m, ...))
+    if ((m > a & m < b) | (ldm1 == 0)) {
+      lk <- ldm + log(b-a)
+    } else {
+      lk <- ldm - log(ldm1) + Rmpfr::log1mexp(ldm1*(b-a))
+    }
+  }
+  # Devroye 1986, Ch. 7, Section 2.3, "Rejection method for log-concave densities. Exponential version"
   x <- rep(NA, n)
-  i <- 1:n
+  i <- seq(n)
   acc <- 0
   j <- 0
-  # if (spec=="gamma" & any(m < 0)) {
-  #   aux <- which(i & m < 0)
-  #   shp <- gammashape(...)[m < 0]
-  #   scl <- gammascale(...)[m < 0]
-  #   a <- pmax(a, 0)
-  #   b <- pmax(b, 0)
-  #   y <- rtruncLCcontinuous(
-  #     n=length(aux),
-  #     spec="epd",
-  #     a = (a/scl)^shp,
-  #     b = (b/scl)^shp,
-  #     beta=1/shp
-  #   )
-  #   acc <- attr(y, "generated")
-  #   x[aux] <- scl*y^(1/shp)
-  #   i <- i[-aux]
-  # }
   # 25% is lower bound on acceptance rate in continuous case
-  maxit <- Rmpfr::log1mexp(truncLCdistoptions("early.stopping.prob")/n)/log(1 - 0.25)
+  if (is.null(maxit)) maxit <- Rmpfr::log1mexp(truncLCdistoptions("early.stopping.prob")/n)/log(1 - 0.25)
   while ((N <- length(i)) & j < maxit) {
+    if (!is.finite(lk)) break
     acc <- acc + N
     U <- 2*runif(N)
     E <- rexp(N)
     Estar <- rexp(N)
     S <- sign(runif(N) - 0.5)
-    x[i] <- ifelse(U > 1, 1 + Estar, U)
+    x[i] <- m + S*ifelse(U > 1, 1 + Estar, U)*exp(lk - ldm)
     Z <- -ifelse(U > 1, E + Estar, E)
-    x[i] <- m + S*x[i]*exp(lk - ldm)
     rej <- x[i] <= a | x[i] > b | Z > ld(x[i], ..., log=T) - ldm
-    rej <- ifelse(is.finite(rej), rej, T) # otherwise, "i" may contain NAs
-    i <- i[rej]
+    i <- i[ifelse(is.finite(rej), rej, T)] # otherwise, "i" may contain NAs
     j <- j + 1
   }
-  if (N > 0) {
-    x[i] <- rep(m, length.out=N)
-  }
+  if (N) x[i] <- m
   attr(x, "iterations") <- j
   attr(x, "imputingmode") <- N/n
   attr(x, "generated") <- acc
   attr(x, "acceptance.rate") <- n/acc
+  attr(x, "location") <- m
+  attr(x, "scale") <- exp(lk - ldm)
   return(x)
 }

--- a/R/rtruncLCdiscrete.R
+++ b/R/rtruncLCdiscrete.R
@@ -1,5 +1,5 @@
 
-rtruncLCdiscrete <- function(n, spec, a = -Inf, b = +Inf, ...) {
+rtruncLCdiscrete <- function(n, spec, a = -Inf, b = +Inf, maxit=NULL, ...) {
   auxmode <- truncLCdistoptions(paste0(spec, ".m"))
   if (is.null(auxmode)) stop("mode unspecified")
   ld <- truncLCdistoptions(paste0(spec, ".d"))
@@ -23,7 +23,7 @@ rtruncLCdiscrete <- function(n, spec, a = -Inf, b = +Inf, ...) {
   acc <- 0
   j <- 0
   # 20% is lower bound on acceptance rate in discrete case
-  maxit <- Rmpfr::log1mexp(truncLCdistoptions("early.stopping.prob")/n)/log(1 - 0.2)
+  if (is.null(maxit)) maxit <- Rmpfr::log1mexp(truncLCdistoptions("early.stopping.prob")/n)/log(1 - 0.2)
   while ((N <- length(i)) & j < maxit) {
     acc <- acc + N
     U <- runif(N)

--- a/R/truncLCdistoptions.R
+++ b/R/truncLCdistoptions.R
@@ -54,9 +54,9 @@ truncLCdistoptions <- futile.options::OptionsManager(
     gamma.exception.raise=function(shape, rate = 1, scale = 1/rate, a=-Inf, b=+Inf) {
       any(shape < 1)
     },
-    gamma.exception.handle=function(n, shape, rate = 1, scale = 1/rate, a=-Inf, b=+Inf) {
+    gamma.exception.handle=function(n, shape, rate = 1, scale = 1/rate, a=-Inf, b=+Inf, maxit=NULL) {
       a <- pmax(a, 0)
-      out <- rtruncLC(n=n, spec="epd", beta=1/shape, a=(a/scale)^shape, b=(b/scale)^shape)
+      out <- rtruncLC(n=n, spec="epd", beta=1/shape, a=(a/scale)^shape, b=(b/scale)^shape, maxit=maxit)
       aux <- attributes(out)
       out <- scale*out^(1/shape)
       attributes(out) <- aux
@@ -73,7 +73,15 @@ truncLCdistoptions <- futile.options::OptionsManager(
     gamma.d=Rmpfr::dgamma,
     gamma.p=pgamma,
     gamma.q=qgamma,
-    gamma.dld=function(x, shape, rate = 1, scale = 1/rate) (shape - 1)/x - lambda,
+    gamma.dld=function(x, shape, rate = 1, scale = 1/rate) (shape - 1)/x - rate,
+
+    # exponential
+    exp.continuous=T,
+    exp.m=function(rate = 1) 0,
+    exp.d=dexp,
+    exp.p=pexp,
+    exp.q=qexp,
+    exp.dld=function(x, rate=1) -rate,
 
     # normal
     norm.continuous=T,
@@ -81,7 +89,7 @@ truncLCdistoptions <- futile.options::OptionsManager(
     norm.d=Rmpfr::dnorm,
     norm.p=Rmpfr::pnorm,
     norm.q=qnorm,
-    norm.dld=function(x, mean = 0, sd = 1) (mu - x)/sigma^2,
+    norm.dld=function(x, mean = 0, sd = 1) (mean - x)/sd^2,
 
     # inverse-Gaussian
     invgauss.continuous=T,
@@ -89,7 +97,7 @@ truncLCdistoptions <- futile.options::OptionsManager(
     invgauss.d=actuar::dinvgauss,
     invgauss.p=actuar::pinvgauss,
     invgauss.q=actuar::qinvgauss,
-    invgauss.dld=function(x, mean, shape = 1, dispersion = 1/shape) -1.5/x - 0.5/mu^2/dispersion + 0.5/dispersion/x^2,
+    invgauss.dld=function(x, mean, shape = 1, dispersion = 1/shape) -1.5/x - 0.5/mean^2/dispersion + 0.5/dispersion/x^2,
 
     # exponential power distribution
     epd.continuous=T,

--- a/man/rtruncLC.Rd
+++ b/man/rtruncLC.Rd
@@ -4,7 +4,7 @@
 \alias{rtruncLC}
 \title{Generate truncated random deviates}
 \usage{
-rtruncLC(n, spec, a = -Inf, b = Inf, ..., its = F)
+rtruncLC(n, spec, a = -Inf, b = Inf, ..., maxit = NULL, its = F)
 }
 \arguments{
 \item{n}{a positive integer for the number of random deviates generated}
@@ -25,6 +25,8 @@ rtruncLC(n, spec, a = -Inf, b = Inf, ..., its = F)
 \item{b}{a numeric value for the upper bound of the random variable}
 
 \item{...}{other arguments are are passed to the corresponding distribution-related functions}
+
+\item{maxit}{integer, maximum number of iterations before imputation}
 
 \item{its}{boolean, whether classical quantile-based sampling à-la truncdist should be performed. Default is FALSE, so Devroye sampling is used instead.}
 }


### PR DESCRIPTION
* There is now an exception handler to redirect the execution in pathological cases (like gamma when shape < 1) or densities are transform-log-concave
* Geweke's exponential approximation tells how to upper bound log-concave tails and allows to improve the safety of the sampler in the continuous case when F(x) fails, based on derivative of log f(x)